### PR TITLE
Decouple touch context

### DIFF
--- a/batcher.go
+++ b/batcher.go
@@ -1,6 +1,7 @@
 package dbl
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -56,7 +57,7 @@ func (b *batcher) run(cs calls) {
 	}
 
 	var failIndex int
-	err := b.core.Transaction(func(txn *Transaction) (err error) {
+	err := b.core.Transaction(context.Background(), func(txn *Transaction) (err error) {
 		failIndex, err = b.performCalls(txn, cs)
 		return
 	})

--- a/context.go
+++ b/context.go
@@ -8,7 +8,8 @@ import (
 	"github.com/hatchify/atoms"
 )
 
-func newContext(ctx context.Context, duration time.Duration) *Context {
+// NewContext will create a new timeout touch context
+func NewContext(ctx context.Context, duration time.Duration) *Context {
 	var c Context
 	c.Context, c.cancel = context.WithCancel(ctx)
 	c.duration = duration
@@ -47,15 +48,6 @@ func (c *Context) stopTimerOnDone() {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 	c.timer.Stop()
-}
-
-func (c *Context) isDone() (done bool) {
-	select {
-	case <-c.Done():
-		done = true
-	}
-
-	return
 }
 
 // Touch will refesh the context timer

--- a/core.go
+++ b/core.go
@@ -234,7 +234,7 @@ func (c *Core) runTransaction(ctx context.Context, txn *bolt.Tx, atxn *actions.T
 
 // New will insert a new entry with the given value and the associated relationships
 func (c *Core) New(val Value) (entryID string, err error) {
-	err = c.Transaction(func(txn *Transaction) (err error) {
+	err = c.Transaction(context.Background(), func(txn *Transaction) (err error) {
 		var id []byte
 		if id, err = txn.new(val); err != nil {
 			return
@@ -249,7 +249,7 @@ func (c *Core) New(val Value) (entryID string, err error) {
 
 // Exists will notiy if an entry exists for a given entry ID
 func (c *Core) Exists(entryID string) (exists bool, err error) {
-	err = c.ReadTransaction(func(txn *Transaction) (err error) {
+	err = c.ReadTransaction(context.Background(), func(txn *Transaction) (err error) {
 		exists, err = txn.exists([]byte(entryID))
 		return
 	})
@@ -259,7 +259,7 @@ func (c *Core) Exists(entryID string) (exists bool, err error) {
 
 // Get will attempt to get an entry by ID
 func (c *Core) Get(entryID string, val Value) (err error) {
-	err = c.ReadTransaction(func(txn *Transaction) (err error) {
+	err = c.ReadTransaction(context.Background(), func(txn *Transaction) (err error) {
 		return txn.get([]byte(entryID), val)
 	})
 
@@ -273,7 +273,7 @@ func (c *Core) GetByRelationship(relationship, relationshipID string, entries in
 		return
 	}
 
-	err = c.ReadTransaction(func(txn *Transaction) (err error) {
+	err = c.ReadTransaction(context.Background(), func(txn *Transaction) (err error) {
 		return txn.getByRelationship([]byte(relationship), []byte(relationshipID), es)
 	})
 
@@ -282,7 +282,7 @@ func (c *Core) GetByRelationship(relationship, relationshipID string, entries in
 
 // GetFirstByRelationship will attempt to get the first entry associated with a given relationship and relationship ID
 func (c *Core) GetFirstByRelationship(relationship, relationshipID string, val Value) (err error) {
-	if err = c.ReadTransaction(func(txn *Transaction) (err error) {
+	if err = c.ReadTransaction(context.Background(), func(txn *Transaction) (err error) {
 		return txn.getFirstByRelationship([]byte(relationship), []byte(relationshipID), val)
 	}); err != nil {
 		return
@@ -293,7 +293,7 @@ func (c *Core) GetFirstByRelationship(relationship, relationshipID string, val V
 
 // GetLastByRelationship will attempt to get the last entry associated with a given relationship and relationship ID
 func (c *Core) GetLastByRelationship(relationship, relationshipID string, val Value) (err error) {
-	if err = c.ReadTransaction(func(txn *Transaction) (err error) {
+	if err = c.ReadTransaction(context.Background(), func(txn *Transaction) (err error) {
 		return txn.getLastByRelationship([]byte(relationship), []byte(relationshipID), val)
 	}); err != nil {
 		return
@@ -304,7 +304,7 @@ func (c *Core) GetLastByRelationship(relationship, relationshipID string, val Va
 
 // ForEach will iterate through each of the entries
 func (c *Core) ForEach(fn ForEachFn) (err error) {
-	err = c.ReadTransaction(func(txn *Transaction) (err error) {
+	err = c.ReadTransaction(context.Background(), func(txn *Transaction) (err error) {
 		return txn.forEach(fn)
 	})
 
@@ -313,7 +313,7 @@ func (c *Core) ForEach(fn ForEachFn) (err error) {
 
 // ForEachRelationship will iterate through each of the entries for a given relationship and relationship ID
 func (c *Core) ForEachRelationship(relationship, relationshipID string, fn ForEachFn) (err error) {
-	err = c.ReadTransaction(func(txn *Transaction) (err error) {
+	err = c.ReadTransaction(context.Background(), func(txn *Transaction) (err error) {
 		return txn.forEachRelationship([]byte(relationship), []byte(relationshipID), fn)
 	})
 
@@ -322,7 +322,7 @@ func (c *Core) ForEachRelationship(relationship, relationshipID string, fn ForEa
 
 // Cursor will return an iterating cursor
 func (c *Core) Cursor(fn CursorFn) (err error) {
-	if err = c.ReadTransaction(func(txn *Transaction) (err error) {
+	if err = c.ReadTransaction(context.Background(), func(txn *Transaction) (err error) {
 		return txn.cursor(fn)
 	}); err == Break {
 		err = nil
@@ -333,7 +333,7 @@ func (c *Core) Cursor(fn CursorFn) (err error) {
 
 // CursorRelationship will return an iterating cursor for a given relationship and relationship ID
 func (c *Core) CursorRelationship(relationship, relationshipID string, fn CursorFn) (err error) {
-	if err = c.ReadTransaction(func(txn *Transaction) (err error) {
+	if err = c.ReadTransaction(context.Background(), func(txn *Transaction) (err error) {
 		return txn.cursorRelationship([]byte(relationship), []byte(relationshipID), fn)
 	}); err == Break {
 		err = nil
@@ -344,7 +344,7 @@ func (c *Core) CursorRelationship(relationship, relationshipID string, fn Cursor
 
 // Edit will attempt to edit an entry by ID
 func (c *Core) Edit(entryID string, val Value) (err error) {
-	err = c.Transaction(func(txn *Transaction) (err error) {
+	err = c.Transaction(context.Background(), func(txn *Transaction) (err error) {
 		return txn.edit([]byte(entryID), val)
 	})
 
@@ -353,7 +353,7 @@ func (c *Core) Edit(entryID string, val Value) (err error) {
 
 // Remove will remove a relationship ID and it's related relationship IDs
 func (c *Core) Remove(entryID string) (err error) {
-	err = c.Transaction(func(txn *Transaction) (err error) {
+	err = c.Transaction(context.Background(), func(txn *Transaction) (err error) {
 		return txn.remove([]byte(entryID))
 	})
 
@@ -362,7 +362,7 @@ func (c *Core) Remove(entryID string) (err error) {
 
 // SetLookup will set a lookup value
 func (c *Core) SetLookup(lookup, lookupID, key string) (err error) {
-	err = c.Transaction(func(txn *Transaction) (err error) {
+	err = c.Transaction(context.Background(), func(txn *Transaction) (err error) {
 		return txn.setLookup([]byte(lookup), []byte(lookupID), []byte(key))
 	})
 
@@ -371,7 +371,7 @@ func (c *Core) SetLookup(lookup, lookupID, key string) (err error) {
 
 // GetLookup will retrieve the matching lookup keys
 func (c *Core) GetLookup(lookup, lookupID string) (keys []string, err error) {
-	err = c.ReadTransaction(func(txn *Transaction) (err error) {
+	err = c.ReadTransaction(context.Background(), func(txn *Transaction) (err error) {
 		keys, err = txn.getLookupKeys([]byte(lookup), []byte(lookupID))
 		return
 	})
@@ -381,7 +381,7 @@ func (c *Core) GetLookup(lookup, lookupID string) (keys []string, err error) {
 
 // GetLookupKey will retrieve the first lookup key
 func (c *Core) GetLookupKey(lookup, lookupID string) (key string, err error) {
-	err = c.ReadTransaction(func(txn *Transaction) (err error) {
+	err = c.ReadTransaction(context.Background(), func(txn *Transaction) (err error) {
 		var keys []string
 		if keys, err = txn.getLookupKeys([]byte(lookup), []byte(lookupID)); err != nil {
 			return
@@ -400,7 +400,7 @@ func (c *Core) GetLookupKey(lookup, lookupID string) (key string, err error) {
 
 // RemoveLookup will set a lookup value
 func (c *Core) RemoveLookup(lookup, lookupID, key string) (err error) {
-	err = c.Transaction(func(txn *Transaction) (err error) {
+	err = c.Transaction(context.Background(), func(txn *Transaction) (err error) {
 		return txn.removeLookup([]byte(lookup), []byte(lookupID), []byte(key))
 	})
 
@@ -408,12 +408,7 @@ func (c *Core) RemoveLookup(lookup, lookupID, key string) (err error) {
 }
 
 // Transaction will initialize a transaction
-func (c *Core) Transaction(fn func(*Transaction) error) (err error) {
-	return c.TransactionWithContext(context.Background(), fn)
-}
-
-// TransactionWithContext will initialize a transaction with a context
-func (c *Core) TransactionWithContext(ctx context.Context, fn func(*Transaction) error) (err error) {
+func (c *Core) Transaction(ctx context.Context, fn func(*Transaction) error) (err error) {
 	err = c.transaction(func(txn *bolt.Tx, atxn *actions.Transaction) (err error) {
 		return c.runTransaction(ctx, txn, atxn, fn)
 	})
@@ -422,12 +417,7 @@ func (c *Core) TransactionWithContext(ctx context.Context, fn func(*Transaction)
 }
 
 // ReadTransaction will initialize a read-only transaction
-func (c *Core) ReadTransaction(fn func(*Transaction) error) (err error) {
-	return c.ReadTransactionWithContext(context.Background(), fn)
-}
-
-// ReadTransactionWithContext will initialize a read-only transaction with a context
-func (c *Core) ReadTransactionWithContext(ctx context.Context, fn func(*Transaction) error) (err error) {
+func (c *Core) ReadTransaction(ctx context.Context, fn func(*Transaction) error) (err error) {
 	err = c.db.View(func(txn *bolt.Tx) (err error) {
 		return c.runTransaction(ctx, txn, nil, fn)
 	})

--- a/core_test.go
+++ b/core_test.go
@@ -112,7 +112,7 @@ func TestCore_Get_context(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		ctx := NewContext(context.Background(), time.Millisecond*200)
+		ctx := NewTouchContext(context.Background(), time.Millisecond*200)
 		if err = c.ReadTransaction(ctx, func(txn *Transaction) (err error) {
 			var fb testStruct
 			for i := 0; i < tc.iterations; i++ {

--- a/core_test.go
+++ b/core_test.go
@@ -1,6 +1,7 @@
 package dbl
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -90,7 +91,6 @@ func TestCore_Get_context(t *testing.T) {
 	}
 	defer testTeardown(c)
 
-	c.opts.TimeoutDuration = time.Millisecond * 200
 	foobar := newTestStruct("user_1", "contact_1", "FOO FOO", "bunny bar bar")
 
 	var entryID string
@@ -112,7 +112,8 @@ func TestCore_Get_context(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		if err = c.ReadTransaction(func(txn *Transaction) (err error) {
+		ctx := NewContext(context.Background(), time.Millisecond*200)
+		if err = c.ReadTransaction(ctx, func(txn *Transaction) (err error) {
 			var fb testStruct
 			for i := 0; i < tc.iterations; i++ {
 				time.Sleep(tc.timeout)

--- a/cursor.go
+++ b/cursor.go
@@ -42,7 +42,7 @@ func (c *Cursor) teardown() {
 
 // Seek will seek the provided ID
 func (c *Cursor) Seek(id string, val Value) (err error) {
-	if !c.txn.ctx.Touch() {
+	if isDone(c.txn.ctx) {
 		return c.txn.ctx.Err()
 	}
 
@@ -61,7 +61,7 @@ func (c *Cursor) Seek(id string, val Value) (err error) {
 
 // First will return the first entry
 func (c *Cursor) First(val Value) (err error) {
-	if !c.txn.ctx.Touch() {
+	if isDone(c.txn.ctx) {
 		return c.txn.ctx.Err()
 	}
 
@@ -80,7 +80,7 @@ func (c *Cursor) First(val Value) (err error) {
 
 // Last will return the last entry
 func (c *Cursor) Last(val Value) (err error) {
-	if !c.txn.ctx.Touch() {
+	if isDone(c.txn.ctx) {
 		return c.txn.ctx.Err()
 	}
 
@@ -99,7 +99,7 @@ func (c *Cursor) Last(val Value) (err error) {
 
 // Next will return the next entry
 func (c *Cursor) Next(val Value) (err error) {
-	if !c.txn.ctx.Touch() {
+	if isDone(c.txn.ctx) {
 		return c.txn.ctx.Err()
 	}
 
@@ -118,7 +118,7 @@ func (c *Cursor) Next(val Value) (err error) {
 
 // Prev will return the previous entry
 func (c *Cursor) Prev(val Value) (err error) {
-	if !c.txn.ctx.Touch() {
+	if isDone(c.txn.ctx) {
 		return c.txn.ctx.Err()
 	}
 

--- a/opts.go
+++ b/opts.go
@@ -9,15 +9,12 @@ const (
 	DefaultMaxBatchDuration = time.Millisecond * 10
 	// DefaultRetryBatchFail is the default value for if a batch call will retry when a batch sibling fails
 	DefaultRetryBatchFail = true
-	// DefaultTimeoutDuration is the default timeout duration for a transaction
-	DefaultTimeoutDuration = time.Second * 12
 )
 
 var defaultOpts = Opts{
 	MaxBatchCalls:    DefaultMaxBatchCalls,
 	MaxBatchDuration: DefaultMaxBatchDuration,
 	RetryBatchFail:   DefaultRetryBatchFail,
-	TimeoutDuration:  DefaultTimeoutDuration,
 }
 
 // Opts represent dbl options
@@ -25,5 +22,4 @@ type Opts struct {
 	MaxBatchCalls    int
 	MaxBatchDuration time.Duration
 	RetryBatchFail   bool
-	TimeoutDuration  time.Duration
 }

--- a/touchContext.go
+++ b/touchContext.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hatchify/atoms"
 )
 
-// NewContext will create a new timeout touch context
-func NewContext(ctx context.Context, duration time.Duration) *Context {
-	var c Context
+// NewTouchContext will create a new timeout touch context
+func NewTouchContext(ctx context.Context, duration time.Duration) *TouchContext {
+	var c TouchContext
 	c.Context, c.cancel = context.WithCancel(ctx)
 	c.duration = duration
 	c.timer = time.NewTimer(duration)
@@ -19,8 +19,8 @@ func NewContext(ctx context.Context, duration time.Duration) *Context {
 	return &c
 }
 
-// Context represents an expiring context that can be refreshed by Touching
-type Context struct {
+// TouchContext represents an expiring context that can be refreshed by Touching
+type TouchContext struct {
 	context.Context
 
 	mux sync.RWMutex
@@ -34,7 +34,7 @@ type Context struct {
 	err      error
 }
 
-func (c *Context) closeOnExpire() {
+func (c *TouchContext) closeOnExpire() {
 	<-c.timer.C
 	c.timedOut.Set(true)
 	c.mux.Lock()
@@ -42,7 +42,7 @@ func (c *Context) closeOnExpire() {
 	c.cancel()
 }
 
-func (c *Context) stopTimerOnDone() {
+func (c *TouchContext) stopTimerOnDone() {
 	<-c.Done()
 
 	c.mux.Lock()
@@ -51,7 +51,7 @@ func (c *Context) stopTimerOnDone() {
 }
 
 // Touch will refesh the context timer
-func (c *Context) Touch() (ok bool) {
+func (c *TouchContext) Touch() (ok bool) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
@@ -68,7 +68,7 @@ func (c *Context) Touch() (ok bool) {
 }
 
 // Err will return the underlying error
-func (c *Context) Err() (err error) {
+func (c *TouchContext) Err() (err error) {
 	c.mux.RLock()
 	defer c.mux.RUnlock()
 	// Check to see if context timed out

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package dbl
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"reflect"
 )
@@ -89,6 +90,22 @@ func recoverCall(txn *Transaction, fn TransactionFn) (err error) {
 	}()
 
 	return fn(txn)
+}
+
+func isDone(ctx context.Context) (done bool) {
+	touch, ok := ctx.(*Context)
+	if ok {
+		// We've encountered a touch Context, perform touch and return the inverse of it's state
+		return !touch.Touch()
+	}
+
+	select {
+	case <-ctx.Done():
+		done = true
+	default:
+	}
+
+	return
 }
 
 // ForEachFn are called during iteration

--- a/utils.go
+++ b/utils.go
@@ -93,7 +93,7 @@ func recoverCall(txn *Transaction, fn TransactionFn) (err error) {
 }
 
 func isDone(ctx context.Context) (done bool) {
-	touch, ok := ctx.(*Context)
+	touch, ok := ctx.(*TouchContext)
 	if ok {
 		// We've encountered a touch Context, perform touch and return the inverse of it's state
 		return !touch.Touch()


### PR DESCRIPTION
The purpose of this PR is to decouple the touch context from dbl Transactions.

```
% go test -v
=== RUN   TestNew
--- PASS: TestNew (0.03s)
=== RUN   TestCore_New
--- PASS: TestCore_New (0.04s)
=== RUN   TestCore_Get
--- PASS: TestCore_Get (0.03s)
=== RUN   TestCore_Get_context
--- PASS: TestCore_Get_context (2.80s)
=== RUN   TestCore_GetByRelationship_users
--- PASS: TestCore_GetByRelationship_users (0.04s)
=== RUN   TestCore_GetByRelationship_contacts
--- PASS: TestCore_GetByRelationship_contacts (0.04s)
=== RUN   TestCore_GetByRelationship_invalid
--- PASS: TestCore_GetByRelationship_invalid (0.03s)
=== RUN   TestCore_GetByRelationship_update
--- PASS: TestCore_GetByRelationship_update (0.05s)
=== RUN   TestCore_GetFirstByRelationship
--- PASS: TestCore_GetFirstByRelationship (0.04s)
=== RUN   TestCore_GetLastByRelationship
--- PASS: TestCore_GetLastByRelationship (0.05s)
=== RUN   TestCore_Edit
--- PASS: TestCore_Edit (0.05s)
=== RUN   TestCore_ForEach
--- PASS: TestCore_ForEach (0.05s)
=== RUN   TestCore_ForEachRelationship
--- PASS: TestCore_ForEachRelationship (0.04s)
=== RUN   TestCore_Cursor
--- PASS: TestCore_Cursor (0.05s)
=== RUN   TestCore_Cursor_First
--- PASS: TestCore_Cursor_First (0.04s)
=== RUN   TestCore_Cursor_Last
--- PASS: TestCore_Cursor_Last (0.05s)
=== RUN   TestCore_Cursor_Seek
--- PASS: TestCore_Cursor_Seek (0.04s)
=== RUN   TestCore_CursorRelationship
--- PASS: TestCore_CursorRelationship (0.05s)
=== RUN   TestCore_Lookups
--- PASS: TestCore_Lookups (0.06s)
=== RUN   TestCore_Batch
--- PASS: TestCore_Batch (0.07s)
PASS
ok      github.com/gdbu/dbl     3.910s
```