### PR TITLE
HV2-1522

### DIFF
--- a/batcher.go
+++ b/batcher.go
@@ -114,9 +114,12 @@ func (b *batcher) flush(ctx context.Context) {
 	b.calls = b.calls[:0]
 }
 
-func (b *batcher) Append(ctx context.Context, fn TransactionFn) (errC chan error) {
+func (b *batcher) Append(fn TransactionFn) (errC chan error) {
 	b.mux.Lock()
 	defer b.mux.Unlock()
+
+	// TODO: discuss implementation of context on Batch
+	ctx := context.Background()
 
 	var c call
 	c.fn = fn

--- a/core.go
+++ b/core.go
@@ -427,7 +427,7 @@ func (c *Core) ReadTransaction(ctx context.Context, fn func(*Transaction) error)
 
 // Batch will initialize a batch
 func (c *Core) Batch(ctx context.Context, fn func(*Transaction) error) (err error) {
-	return <-c.b.Append(ctx, fn)
+	return <-c.b.Append(fn)
 }
 
 // Close will close the selected instance of Core

--- a/core.go
+++ b/core.go
@@ -426,8 +426,8 @@ func (c *Core) ReadTransaction(ctx context.Context, fn func(*Transaction) error)
 }
 
 // Batch will initialize a batch
-func (c *Core) Batch(fn func(*Transaction) error) (err error) {
-	return <-c.b.Append(fn)
+func (c *Core) Batch(ctx context.Context, fn func(*Transaction) error) (err error) {
+	return <-c.b.Append(ctx, fn)
 }
 
 // Close will close the selected instance of Core

--- a/core_test.go
+++ b/core_test.go
@@ -777,14 +777,14 @@ func TestCore_Batch(t *testing.T) {
 	foobar := newTestStruct("user_1", "contact_1", "FOO FOO", "bunny bar bar")
 
 	var entryID string
-	if err = c.Batch(func(txn *Transaction) (err error) {
+	if err = c.Batch(context.Background(), func(txn *Transaction) (err error) {
 		entryID, err = txn.New(&foobar)
 		return
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = c.Batch(func(txn *Transaction) (err error) {
+	if err = c.Batch(context.Background(), func(txn *Transaction) (err error) {
 		foobar.Foo = "foo"
 		foobar.Bar = "bar"
 		err = txn.Edit(entryID, &foobar)
@@ -911,7 +911,7 @@ func benchmarkCoreBatch(b *testing.B, threads int) {
 	b.SetParallelism(threads)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			if err = c.Batch(func(txn *Transaction) (err error) {
+			if err = c.Batch(context.Background(), func(txn *Transaction) (err error) {
 				_, err = txn.New(&foobar)
 				return
 			}); err != nil {

--- a/transaction.go
+++ b/transaction.go
@@ -745,5 +745,10 @@ func (t *Transaction) RemoveLookup(lookup, lookupID, key string) (err error) {
 	return t.removeLookup([]byte(lookup), []byte(lookupID), []byte(key))
 }
 
+// GetContext will return a transactions underlying context
+func (t *Transaction) GetContext() (ctx context.Context) {
+	return t.ctx
+}
+
 // TransactionFn represents a transaction function
 type TransactionFn func(*Transaction) error


### PR DESCRIPTION
Purpose of this PR is to make underlying methods of Batch take transaction as an arg.  Currently, we will only be passing `context.Background()` via the `Append` method.

Also included new method for `GetContext` to allow returning of a Transaction instance's underlying context.

We will need to discuss the best way to pass a context through to Batch.  For now, this just gets the majority of the leg work out of the way.