### PR TITLE
Implement many to many relationships

### DIFF
--- a/core.go
+++ b/core.go
@@ -67,7 +67,7 @@ func New(name, dir string, example Value, relationships ...string) (cc *Core, er
 // NewWithOpts will return a new instance of Core
 func NewWithOpts(name, dir string, example Value, opts Opts, relationships ...string) (cc *Core, err error) {
 	var c Core
-	if len(example.GetRelationshipIDs()) != len(relationships) {
+	if len(example.GetRelationships()) != len(relationships) {
 		err = ErrInvalidNumberOfRelationships
 		return
 	}

--- a/core_test.go
+++ b/core_test.go
@@ -1205,15 +1205,13 @@ func newTestStruct(userID, contactID, groupID, value string) (t testStruct) {
 }
 
 type testStruct struct {
-	ID        string `json:"id"`
+	Entry
+
 	UserID    string `json:"userID"`
 	ContactID string `json:"contactID"`
 	GroupID   string `json:"groupID"`
 
 	Value string `json:"value"`
-
-	UpdatedAt int64 `json:"updatedAt"`
-	CreatedAt int64 `json:"createdAt"`
 }
 
 func (t *testStruct) SetID(id string) {
@@ -1232,10 +1230,10 @@ func (t *testStruct) GetID() (id string) {
 	return t.ID
 }
 
-func (t *testStruct) GetRelationshipIDs() (ids []string) {
-	ids = append(ids, t.UserID)
-	ids = append(ids, t.ContactID)
-	ids = append(ids, t.GroupID)
+func (t *testStruct) GetRelationships() (r Relationships) {
+	r.Append(t.UserID)
+	r.Append(t.ContactID)
+	r.Append(t.GroupID)
 	return
 }
 

--- a/entry.go
+++ b/entry.go
@@ -32,8 +32,8 @@ func (e *Entry) GetUpdatedAt() (updatedAt int64) {
 // has been changed to ensure previous use of this method would be easily caught by
 // the compiler. If this method was removed, the fear is that the prior use of the
 // unused method would still continue (since the interface would still technically match).
-func (e *Entry) GetRelationshipIDs(deprecated string) {
-	return
+func (e *Entry) GetRelationshipIDs() []string {
+	return nil
 }
 
 // GetRelationships will get the associated relationships

--- a/entry.go
+++ b/entry.go
@@ -32,8 +32,8 @@ func (e *Entry) GetUpdatedAt() (updatedAt int64) {
 // has been changed to ensure previous use of this method would be easily caught by
 // the compiler. If this method was removed, the fear is that the prior use of the
 // unused method would still continue (since the interface would still technically match).
-func (e *Entry) GetRelationshipIDs() []string {
-	return nil
+func (e *Entry) GetRelationshipIDs() (ids []string) {
+	return
 }
 
 // GetRelationships will get the associated relationships

--- a/entry.go
+++ b/entry.go
@@ -28,7 +28,7 @@ func (e *Entry) GetUpdatedAt() (updatedAt int64) {
 }
 
 // GetRelationshipIDs will get the associated relationship IDs
-// Note: This method is now deprecated. The method has been kept and the signature
+// Deprecated: This method is now deprecated. The method has been kept and the signature
 // has been changed to ensure previous use of this method would be easily caught by
 // the compiler. If this method was removed, the fear is that the prior use of the
 // unused method would still continue (since the interface would still technically match).

--- a/entry.go
+++ b/entry.go
@@ -29,7 +29,13 @@ func (e *Entry) GetUpdatedAt() (updatedAt int64) {
 
 // GetRelationshipIDs will get the associated relationship IDs
 // Note: This will have to be replaced by the including entry if relationships are needed
-func (e *Entry) GetRelationshipIDs() (ids []string) {
+func (e *Entry) GetRelationshipIDs(deprecated string) {
+	return
+}
+
+// GetRelationships will get the associated relationships
+// Note: This will have to be replaced by the including entry if relationships are needed
+func (e *Entry) GetRelationships() (r Relationships) {
 	return
 }
 

--- a/entry.go
+++ b/entry.go
@@ -28,7 +28,10 @@ func (e *Entry) GetUpdatedAt() (updatedAt int64) {
 }
 
 // GetRelationshipIDs will get the associated relationship IDs
-// Note: This will have to be replaced by the including entry if relationships are needed
+// Note: This method is now deprecated. The method has been kept and the signature
+// has been changed to ensure previous use of this method would be easily caught by
+// the compiler. If this method was removed, the fear is that the prior use of the
+// unused method would still continue (since the interface would still technically match).
 func (e *Entry) GetRelationshipIDs(deprecated string) {
 	return
 }

--- a/relationships.go
+++ b/relationships.go
@@ -22,8 +22,7 @@ func (r Relationship) Has(relationshipID string) (has bool) {
 	return false
 }
 
-// Delta will call onAdd and onRemove for the delta entries between the current and old Relationship
-func (r Relationship) Delta(old Relationship, onAdd, onRemove RelationshipFn) (err error) {
+func (r Relationship) delta(old Relationship, onAdd, onRemove RelationshipFn) (err error) {
 	if err = r.addNew(old, onAdd); err != nil {
 		return
 	}

--- a/relationships.go
+++ b/relationships.go
@@ -1,0 +1,67 @@
+package dbl
+
+// Relationships help to store the relationships for an Entry
+type Relationships []Relationship
+
+// Append will append a set of relationship IDs for a given relationship
+func (r *Relationships) Append(relationshipIDs ...string) {
+	*r = append(*r, relationshipIDs)
+}
+
+// Relationship help to store the IDs for an Entry's relationship
+type Relationship []string
+
+// Has will note if a relationship has a particular relationship ID
+func (r Relationship) Has(relationshipID string) (has bool) {
+	for _, id := range r {
+		if id == relationshipID {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Delta will call onAdd and onRemove for the delta entries between the current and old Relationship
+func (r Relationship) Delta(old Relationship, onAdd, onRemove RelationshipFn) (err error) {
+	if err = r.addNew(old, onAdd); err != nil {
+		return
+	}
+
+	if err = r.removeOld(old, onRemove); err != nil {
+		return
+	}
+
+	return
+}
+
+func (r Relationship) addNew(old Relationship, onAdd RelationshipFn) (err error) {
+	for _, id := range r {
+		if old.Has(id) {
+			continue
+		}
+
+		if err = onAdd([]byte(id)); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func (r Relationship) removeOld(old Relationship, onRemove RelationshipFn) (err error) {
+	for _, id := range old {
+		if r.Has(id) {
+			continue
+		}
+
+		if err = onRemove([]byte(id)); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// RelationshipFn is called for relationship comparison funcs
+type RelationshipFn func(relationshipID []byte) error

--- a/relationships.go
+++ b/relationships.go
@@ -1,5 +1,15 @@
 package dbl
 
+// Note: This is to support the deprecated GetRelationshipIDs method.
+// This will be removed in v0.6.0
+func newRelationshipsFromIDs(relationshipIDs []string) (r Relationships) {
+	for _, id := range relationshipIDs {
+		r.Append(id)
+	}
+
+	return
+}
+
 // Relationships help to store the relationships for an Entry
 type Relationships []Relationship
 

--- a/transaction.go
+++ b/transaction.go
@@ -469,7 +469,7 @@ func (t *Transaction) updateRelationships(entryID []byte, orig, val Value) (err 
 			return t.unsetRelationship(t.c.relationships[i], relationshipID, entryID)
 		}
 
-		relationship.Delta(origRelationships[i], onAdd, onRemove)
+		relationship.delta(origRelationships[i], onAdd, onRemove)
 	}
 
 	return

--- a/transaction.go
+++ b/transaction.go
@@ -460,6 +460,11 @@ func (t *Transaction) updateRelationships(entryID []byte, orig, val Value) (err 
 	origRelationships := orig.GetRelationships()
 	newRelationships := val.GetRelationships()
 
+	if len(origRelationships) == 0 && len(origRelationships) == 0 {
+		origRelationships = newRelationshipsFromIDs(orig.GetRelationshipIDs())
+		newRelationships = newRelationshipsFromIDs(val.GetRelationshipIDs())
+	}
+
 	for i, relationship := range newRelationships {
 		onAdd := func(relationshipID []byte) (err error) {
 			return t.setRelationship(t.c.relationships[i], relationshipID, entryID)

--- a/transaction.go
+++ b/transaction.go
@@ -377,14 +377,17 @@ func (t *Transaction) delete(entryID []byte) (err error) {
 	return bkt.Delete(entryID)
 }
 
-func (t *Transaction) setRelationships(relationshipIDs []string, entryID []byte) (err error) {
+func (t *Transaction) setRelationships(relationships Relationships, entryID []byte) (err error) {
 	if isDone(t.ctx) {
 		return t.ctx.Err()
 	}
 
-	for i, relationshipID := range relationshipIDs {
-		if err = t.setRelationship(t.c.relationships[i], []byte(relationshipID), entryID); err != nil {
-			return
+	for i, relationship := range relationships {
+		relationshipKey := t.c.relationships[i]
+		for _, relationshipID := range relationship {
+			if err = t.setRelationship(relationshipKey, []byte(relationshipID), entryID); err != nil {
+				return
+			}
 		}
 	}
 
@@ -414,14 +417,17 @@ func (t *Transaction) setRelationship(relationship, relationshipID, entryID []by
 	return bkt.Put(entryID, nil)
 }
 
-func (t *Transaction) unsetRelationships(relationshipIDs []string, entryID []byte) (err error) {
+func (t *Transaction) unsetRelationships(relationships Relationships, entryID []byte) (err error) {
 	if isDone(t.ctx) {
 		return t.ctx.Err()
 	}
 
-	for i, relationshipID := range relationshipIDs {
-		if err = t.unsetRelationship(t.c.relationships[i], []byte(relationshipID), entryID); err != nil {
-			return
+	for i, relationship := range relationships {
+		relationshipKey := t.c.relationships[i]
+		for _, relationshipID := range relationship {
+			if err = t.unsetRelationship(relationshipKey, []byte(relationshipID), entryID); err != nil {
+				return
+			}
 		}
 	}
 
@@ -451,19 +457,19 @@ func (t *Transaction) updateRelationships(entryID []byte, orig, val Value) (err 
 		return t.ctx.Err()
 	}
 
-	origRelationships := orig.GetRelationshipIDs()
-	newRelationships := val.GetRelationshipIDs()
-	if isSliceMatch(origRelationships, newRelationships) {
-		// Relationships already match, return
-		return
-	}
+	origRelationships := orig.GetRelationships()
+	newRelationships := val.GetRelationships()
 
-	if err = t.unsetRelationships(origRelationships, entryID); err != nil {
-		return
-	}
+	for i, relationship := range newRelationships {
+		onAdd := func(relationshipID []byte) (err error) {
+			return t.setRelationship(t.c.relationships[i], relationshipID, entryID)
+		}
 
-	if err = t.setRelationships(newRelationships, entryID); err != nil {
-		return
+		onRemove := func(relationshipID []byte) (err error) {
+			return t.unsetRelationship(t.c.relationships[i], relationshipID, entryID)
+		}
+
+		relationship.Delta(origRelationships[i], onAdd, onRemove)
 	}
 
 	return
@@ -622,7 +628,7 @@ func (t *Transaction) new(val Value) (entryID []byte, err error) {
 		return
 	}
 
-	if err = t.setRelationships(val.GetRelationshipIDs(), entryID); err != nil {
+	if err = t.setRelationships(val.GetRelationships(), entryID); err != nil {
 		return
 	}
 
@@ -678,7 +684,7 @@ func (t *Transaction) remove(entryID []byte) (err error) {
 		return
 	}
 
-	if err = t.unsetRelationships(val.GetRelationshipIDs(), entryID); err != nil {
+	if err = t.unsetRelationships(val.GetRelationships(), entryID); err != nil {
 		return
 	}
 

--- a/value.go
+++ b/value.go
@@ -6,11 +6,11 @@ type Value interface {
 	GetCreatedAt() int64
 	GetUpdatedAt() int64
 	GetRelationships() Relationships
-	// Note: This method is now deprecated. The method has been kept and the signature
+	// Deprecated: This method is now deprecated. The method has been kept and the signature
 	// has been changed to ensure previous use of this method would be easily caught by
 	// the compiler. If this method was removed, the fear is that the prior use of the
 	// unused method would still continue (since the interface would still technically match).
-	GetRelationshipIDs(deprecated string)
+	GetRelationshipIDs() []string
 
 	SetID(string)
 	SetCreatedAt(int64)

--- a/value.go
+++ b/value.go
@@ -6,6 +6,10 @@ type Value interface {
 	GetCreatedAt() int64
 	GetUpdatedAt() int64
 	GetRelationships() Relationships
+	// Note: This method is now deprecated. The method has been kept and the signature
+	// has been changed to ensure previous use of this method would be easily caught by
+	// the compiler. If this method was removed, the fear is that the prior use of the
+	// unused method would still continue (since the interface would still technically match).
 	GetRelationshipIDs(deprecated string)
 
 	SetID(string)

--- a/value.go
+++ b/value.go
@@ -5,7 +5,8 @@ type Value interface {
 	GetID() string
 	GetCreatedAt() int64
 	GetUpdatedAt() int64
-	GetRelationshipIDs() []string
+	GetRelationships() Relationships
+	GetRelationshipIDs(deprecated string)
 
 	SetID(string)
 	SetCreatedAt(int64)


### PR DESCRIPTION
```
 % go test -v                                              
=== RUN   TestNew
--- PASS: TestNew (0.03s)
=== RUN   TestCore_New
--- PASS: TestCore_New (0.04s)
=== RUN   TestCore_Get
--- PASS: TestCore_Get (0.03s)
=== RUN   TestCore_Get_context
--- PASS: TestCore_Get_context (2.80s)
=== RUN   TestCore_GetByRelationship_users
--- PASS: TestCore_GetByRelationship_users (0.04s)
=== RUN   TestCore_GetByRelationship_contacts
--- PASS: TestCore_GetByRelationship_contacts (0.04s)
=== RUN   TestCore_GetByRelationship_invalid
--- PASS: TestCore_GetByRelationship_invalid (0.04s)
=== RUN   TestCore_GetByRelationship_update
--- PASS: TestCore_GetByRelationship_update (0.06s)
=== RUN   TestCore_GetByRelationship_many_to_many
--- PASS: TestCore_GetByRelationship_many_to_many (0.13s)
=== RUN   TestCore_GetFirstByRelationship
--- PASS: TestCore_GetFirstByRelationship (0.05s)
=== RUN   TestCore_GetLastByRelationship
--- PASS: TestCore_GetLastByRelationship (0.05s)
=== RUN   TestCore_Edit
--- PASS: TestCore_Edit (0.05s)
=== RUN   TestCore_ForEach
--- PASS: TestCore_ForEach (0.04s)
=== RUN   TestCore_ForEach_with_filter
--- PASS: TestCore_ForEach_with_filter (0.05s)
=== RUN   TestCore_ForEach_with_multiple_filters
--- PASS: TestCore_ForEach_with_multiple_filters (0.07s)
=== RUN   TestCore_Cursor
--- PASS: TestCore_Cursor (0.05s)
=== RUN   TestCore_Cursor_First
--- PASS: TestCore_Cursor_First (0.05s)
=== RUN   TestCore_Cursor_Last
--- PASS: TestCore_Cursor_Last (0.05s)
=== RUN   TestCore_Cursor_Seek
--- PASS: TestCore_Cursor_Seek (0.05s)
=== RUN   TestCore_CursorRelationship
--- PASS: TestCore_CursorRelationship (0.05s)
=== RUN   TestCore_Lookups
--- PASS: TestCore_Lookups (0.06s)
=== RUN   TestCore_Batch
--- PASS: TestCore_Batch (0.07s)
PASS
ok      github.com/gdbu/dbl     3.977s
```