### PR TITLE
Make encoding interface

### DIFF
--- a/core.go
+++ b/core.go
@@ -2,7 +2,6 @@ package dbl
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -67,6 +66,10 @@ func New(name, dir string, example Value, relationships ...string) (cc *Core, er
 // NewWithOpts will return a new instance of Core
 func NewWithOpts(name, dir string, example Value, opts Opts, relationships ...string) (cc *Core, err error) {
 	var c Core
+	if err = opts.Validate(); err != nil {
+		return
+	}
+
 	if len(example.GetRelationships()) != len(relationships) {
 		err = ErrInvalidNumberOfRelationships
 		return
@@ -200,9 +203,17 @@ func (c *Core) newEntryValue() (value Value) {
 	return iface.(Value)
 }
 
+func (c *Core) marshal(val interface{}) (bs []byte, err error) {
+	return c.opts.Encoder.Marshal(val)
+}
+
+func (c *Core) unmarshal(bs []byte, val interface{}) (err error) {
+	return c.opts.Encoder.Unmarshal(bs, val)
+}
+
 func (c *Core) newValueFromBytes(bs []byte) (val Value, err error) {
 	val = c.newEntryValue()
-	if err = json.Unmarshal(bs, val); err != nil {
+	if err = c.unmarshal(bs, val); err != nil {
 		val = nil
 		return
 	}

--- a/cursor.go
+++ b/cursor.go
@@ -1,10 +1,6 @@
 package dbl
 
-import (
-	"encoding/json"
-
-	"github.com/boltdb/bolt"
-)
+import "github.com/boltdb/bolt"
 
 func newCursor(txn *Transaction, cur *bolt.Cursor, relationship bool) (c Cursor) {
 	c.txn = txn
@@ -15,16 +11,15 @@ func newCursor(txn *Transaction, cur *bolt.Cursor, relationship bool) (c Cursor)
 
 // Cursor is an iterating structure
 type Cursor struct {
-	core *Core
-	txn  *Transaction
-	cur  *bolt.Cursor
+	txn *Transaction
+	cur *bolt.Cursor
 
 	relationship bool
 }
 
 func (c *Cursor) get(key, bs []byte, val Value) (err error) {
 	if !c.relationship {
-		return json.Unmarshal(bs, val)
+		return c.txn.c.unmarshal(bs, val)
 	}
 
 	if err = c.txn.get(key, val); err != nil {

--- a/encoder.go
+++ b/encoder.go
@@ -1,0 +1,22 @@
+package dbl
+
+import "encoding/json"
+
+// Encoder represents an encoder for DBL Entries
+type Encoder interface {
+	Marshal(interface{}) ([]byte, error)
+	Unmarshal([]byte, interface{}) error
+}
+
+// JSONEncoder represents a JSON encoder
+type JSONEncoder struct{}
+
+// Marshal is an encoding helper method
+func (j *JSONEncoder) Marshal(value interface{}) (bs []byte, err error) {
+	return json.Marshal(value)
+}
+
+// Unmarshal is a decoding helper method
+func (j *JSONEncoder) Unmarshal(bs []byte, val interface{}) (err error) {
+	return json.Unmarshal(bs, val)
+}

--- a/opts.go
+++ b/opts.go
@@ -1,6 +1,10 @@
 package dbl
 
-import "time"
+import (
+	"time"
+
+	"github.com/hatchify/errors"
+)
 
 const (
 	// DefaultMaxBatchCalls is the default maximum number of calls a batch will take
@@ -9,6 +13,14 @@ const (
 	DefaultMaxBatchDuration = time.Millisecond * 10
 	// DefaultRetryBatchFail is the default value for if a batch call will retry when a batch sibling fails
 	DefaultRetryBatchFail = true
+)
+
+// DefaultEncoder represents the default encoder used by DBL
+var DefaultEncoder JSONEncoder
+
+const (
+	// ErrEmptyEncoder is returned when an encoder is unset
+	ErrEmptyEncoder = errors.Error("invalid encoder, cannot be empty")
 )
 
 var defaultOpts = Opts{
@@ -22,4 +34,26 @@ type Opts struct {
 	MaxBatchCalls    int
 	MaxBatchDuration time.Duration
 	RetryBatchFail   bool
+
+	Encoder Encoder
+}
+
+// Validate will validate a set of Options
+func (o *Opts) Validate() (err error) {
+	o.init()
+	return
+}
+
+func (o *Opts) init() {
+	if o.Encoder == nil {
+		o.Encoder = &DefaultEncoder
+	}
+
+	if o.MaxBatchCalls == 0 {
+		o.MaxBatchCalls = DefaultMaxBatchCalls
+	}
+
+	if o.MaxBatchDuration == 0 {
+		o.MaxBatchDuration = DefaultMaxBatchDuration
+	}
 }

--- a/transaction.go
+++ b/transaction.go
@@ -3,7 +3,6 @@ package dbl
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"time"
@@ -86,7 +85,7 @@ func (t *Transaction) get(entryID []byte, val interface{}) (err error) {
 		return
 	}
 
-	err = json.Unmarshal(bs, val)
+	err = t.c.unmarshal(bs, val)
 	return
 }
 
@@ -389,7 +388,7 @@ func (t *Transaction) put(entryID []byte, val Value) (err error) {
 	val.SetUpdatedAt(time.Now().Unix())
 
 	var bs []byte
-	if bs, err = json.Marshal(val); err != nil {
+	if bs, err = t.c.marshal(val); err != nil {
 		return
 	}
 


### PR DESCRIPTION
```
% go test --v
=== RUN   TestNew
--- PASS: TestNew (0.02s)
=== RUN   TestCore_New
--- PASS: TestCore_New (0.04s)
=== RUN   TestCore_Get
--- PASS: TestCore_Get (0.04s)
=== RUN   TestCore_Get_context
--- PASS: TestCore_Get_context (2.79s)
=== RUN   TestCore_GetByRelationship_users
--- PASS: TestCore_GetByRelationship_users (0.04s)
=== RUN   TestCore_GetByRelationship_contacts
--- PASS: TestCore_GetByRelationship_contacts (0.04s)
=== RUN   TestCore_GetByRelationship_invalid
--- PASS: TestCore_GetByRelationship_invalid (0.04s)
=== RUN   TestCore_GetByRelationship_update
--- PASS: TestCore_GetByRelationship_update (0.05s)
=== RUN   TestCore_GetByRelationship_many_to_many
--- PASS: TestCore_GetByRelationship_many_to_many (0.15s)
=== RUN   TestCore_GetFiltered_many_to_many
--- PASS: TestCore_GetFiltered_many_to_many (0.13s)
=== RUN   TestCore_GetFirstByRelationship
--- PASS: TestCore_GetFirstByRelationship (0.04s)
=== RUN   TestCore_GetLastByRelationship
--- PASS: TestCore_GetLastByRelationship (0.06s)
=== RUN   TestCore_Edit
--- PASS: TestCore_Edit (0.05s)
=== RUN   TestCore_ForEach
--- PASS: TestCore_ForEach (0.05s)
=== RUN   TestCore_ForEach_with_filter
--- PASS: TestCore_ForEach_with_filter (0.05s)
=== RUN   TestCore_ForEach_with_multiple_filters
--- PASS: TestCore_ForEach_with_multiple_filters (0.07s)
=== RUN   TestCore_Cursor
--- PASS: TestCore_Cursor (0.04s)
=== RUN   TestCore_Cursor_First
--- PASS: TestCore_Cursor_First (0.05s)
=== RUN   TestCore_Cursor_Last
--- PASS: TestCore_Cursor_Last (0.05s)
=== RUN   TestCore_Cursor_Seek
--- PASS: TestCore_Cursor_Seek (0.07s)
=== RUN   TestCore_CursorRelationship
--- PASS: TestCore_CursorRelationship (0.05s)
=== RUN   TestCore_Lookups
--- PASS: TestCore_Lookups (0.06s)
=== RUN   TestCore_Batch
--- PASS: TestCore_Batch (0.07s)
=== RUN   TestCore_index_increment_persist
--- PASS: TestCore_index_increment_persist (0.06s)
=== RUN   Test_stripLeadingZeros
--- PASS: Test_stripLeadingZeros (0.00s)
PASS
ok      github.com/gdbu/dbl     4.241s
```